### PR TITLE
Removed compiler warnings. Fixed one out of range array access and an uninitialized variable.

### DIFF
--- a/ED4scan/ED4scan.h
+++ b/ED4scan/ED4scan.h
@@ -19,7 +19,7 @@
 //! \brief   Definitions and structures for the main program ED4scan.ino
 //! \date    2018-April
 //! \author  MyLab-odyssey
-//! \version 0.4.2
+//! \version 0.4.3
 //--------------------------------------------------------------------------------
 
 #define VERBOSE 1                //!< Set default VERBOSE mode to output individual cell data
@@ -34,7 +34,7 @@
 #include "canDiagED4.h"
 
 //Global definitions
-char* const PROGMEM version = "0.4.2";
+const char* const PROGMEM version = "0.4.3";
 
 #define FAILURE F("* FAIL *")
 #define MSG_OK F("OK")
@@ -45,7 +45,7 @@ char* const PROGMEM version = "0.4.2";
 #define MSG_A_STATUS F(", amps & status")
 #define MSG_T F(" t     Temperatures")
 
-char* const PROGMEM ON_OFF[] ={"OFF", "ON"};
+const char* const PROGMEM ON_OFF[] ={"OFF", "ON"};
 
 #define CS     10                //!< chip select pin of MCP2515 CAN-Controller
 #define CS_SD  8                 //!< CS for SD card, if you plan to use a logger...

--- a/ED4scan/ED4scan_CLI.ino
+++ b/ED4scan/ED4scan_CLI.ino
@@ -19,7 +19,7 @@
 //! \brief   Functions for the Command Line Interface (CLI) menu system
 //! \date    2018-April
 //! \author  MyLab-odyssey
-//! \version 0.4.2
+//! \version 0.4.3
 //--------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------
@@ -50,6 +50,7 @@ void setupMenu() {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void get_all (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // Avoid unused param warning
   switch (myDevice.menu) {
     case subBMS:
       printBMSall();
@@ -73,6 +74,7 @@ void get_all (uint8_t arg_cnt, char **args) {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void get_temperatures (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // Avoid unused param warning
   switch (myDevice.menu) {
     case subBMS:
       if (DiagCAN.getBatteryTemperature(&BMS, false)){
@@ -96,6 +98,7 @@ void get_temperatures (uint8_t arg_cnt, char **args) {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void get_voltages (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // Avoid unused param warning
   byte bms_sel[] = {BMSstate, BMSlimit, BMSbal};
   switch (myDevice.menu) {
     case subBMS:
@@ -121,6 +124,7 @@ void get_voltages (uint8_t arg_cnt, char **args) {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void get_OCVtable (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // Avoid unused param warning
   switch (myDevice.menu) {
     case subBMS:
         PrintSPACER(F("OCV Lookup"));
@@ -138,6 +142,7 @@ void get_OCVtable (uint8_t arg_cnt, char **args) {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void get_RESfactors (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // Avoid unused param warning
   switch (myDevice.menu) {
     case subBMS:
         PrintSPACER(F("Cell Resistance"));
@@ -155,6 +160,7 @@ void get_RESfactors (uint8_t arg_cnt, char **args) {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void get_BMSlog (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // Avoid unused param warning
   switch (myDevice.menu) {
     case subBMS:
         PrintSPACER(F("BMS Log"));
@@ -172,6 +178,7 @@ void get_BMSlog (uint8_t arg_cnt, char **args) {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void get_SOHstate (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // Avoid unused param warning
   byte bms_sel[] = {3,5};
   switch (myDevice.menu) {
     case subBMS:
@@ -191,6 +198,7 @@ void get_SOHstate (uint8_t arg_cnt, char **args) {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void get_CHGlog (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // Avoid unused param warning
   switch (myDevice.menu) {
     case subBMS:
     case subOBL:
@@ -210,6 +218,7 @@ void get_CHGlog (uint8_t arg_cnt, char **args) {
 #ifdef HELP
 void help(uint8_t arg_cnt, char **args)
 {
+  (void) arg_cnt, (void) args;  // Avoid unused param warning
   switch (myDevice.menu) {
     case MAIN:
       Serial.println(F("Main:"));
@@ -246,6 +255,7 @@ void help(uint8_t arg_cnt, char **args)
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void show_splash(uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // Avoid unused param warning
    byte selected[] = {BMSstate, BMSsoc, BMSlimit, EVkey, EVdcdc, EVodo, EVrange};
    getState_BMS(selected, sizeof(selected));
    printSplashScreen();
@@ -257,6 +267,7 @@ void show_splash(uint8_t arg_cnt, char **args) {
 //--------------------------------------------------------------------------------
 void show_info(uint8_t arg_cnt, char **args)
 {
+  (void) arg_cnt, (void) args;  // Avoid unused param warning
   //Serial.print(F("Usable Memory: ")); Serial.println(getFreeRam());
   //Serial.print(F("Menu: ")); Serial.println(myDevice.menu);
   Serial.print(F("OBC     : ")); 
@@ -381,6 +392,7 @@ void init_cmd_prompt() {
 //! \param   Argument count (int) and argument-list (char*) from Cmd.h
 //--------------------------------------------------------------------------------
 void main_menu (uint8_t arg_cnt, char **args) {
+  (void) arg_cnt, (void) args;  // Avoid unused param warning
   myDevice.menu = MAIN;
   init_cmd_prompt();
 }

--- a/ED4scan/ED4scan_PRN.ino
+++ b/ED4scan/ED4scan_PRN.ino
@@ -19,7 +19,7 @@
 //! \brief   Functions for serial printing the datasets
 //! \date    2018-April
 //! \author  MyLab-odyssey
-//! \version 0.4.2
+//! \version 0.4.3
 //--------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------
@@ -31,7 +31,7 @@ void PrintSPACER() {
   Serial.println();
 }
 
-void PrintSPACER(__FlashStringHelper* titel) {
+void PrintSPACER(const __FlashStringHelper* titel) {
   size_t len = getLength(titel) + 4;
   byte start = 4; //(42 - len) / 6;
 
@@ -97,6 +97,7 @@ void printHeaderData() {
 //! \brief   Output battery production data and battery status SOH flag
 //--------------------------------------------------------------------------------
 void printBatteryProductionData(boolean fRPT) {
+  (void) fRPT;  // Avoid unused param warning
   Serial.print(F("SOH  : ")); Serial.print(BMS.SOH); Serial.print(F("%, "));
   if (BMS.fSOH == 0xFF) {
     Serial.println(MSG_OK);
@@ -153,7 +154,7 @@ void printStandardDataset() {
   Serial.print(BMS.LV_DCDC_load / 256.0 * 100.0,0); Serial.println(F(" %"));
   Serial.print(F("EV   : "));
   Serial.print((char *) pgm_read_word(ON_OFF + (BMS.KeyState))); Serial.print(F(", ")); 
-  if (BMS.EVmode >= 0 && BMS.EVmode <= 3) {
+  if (BMS.EVmode <= 3) {
     Serial.print((char *) pgm_read_word(EVMODES + BMS.EVmode));
   } else {
     Serial.print(BMS.EVmode, HEX);
@@ -509,7 +510,7 @@ void printTCUdata() {
 //! \brief   The allocated memory will be released after the data output
 //--------------------------------------------------------------------------------
 void printBMSall() {
-  byte selected[BMSCOUNT];   //hold list for selected tasks
+  byte selected[12];   //hold list for selected tasks
   
   //Read all CAN-Bus IDs related to BMS
   for (byte i = 0; i < BMSCOUNT; i++) {

--- a/ED4scan/_BMS_ED4_dfs.h
+++ b/ED4scan/_BMS_ED4_dfs.h
@@ -19,7 +19,7 @@
 //! \brief   Definitions and structures for the BMS module.
 //! \date    2018-April
 //! \author  MyLab-odyssey
-//! \version 0.4.2
+//! \version 0.4.3
 //--------------------------------------------------------------------------------
 #ifndef BMS_ED4_DFS_H
 #define BMS_ED4_DFS_H
@@ -30,20 +30,20 @@
 #define RAW_VOLTAGES 0           //!< Use RAW values or calc with ADC resolution 
 #define IQR_FACTOR 1.5           //!< Factor to define Outliners-Range, 1.5 for suspected outliners, 3 for definitive outliners
 
-char* const PROGMEM EVMODES[] ={"HV OFF", "slow CHG", "fast CHG", "HV ON"};
-char* const PROGMEM CAPMODES[] ={"As/10", "As/100"};
+const char* const PROGMEM EVMODES[] ={"HV OFF", "slow CHG", "fast CHG", "HV ON"};
+const char* const PROGMEM CAPMODES[] ={"As/10", "As/100"};
 
 //Data structure for statistics (min, mean, max values, percentiles)
 template<typename T>
 struct Stats_t{
-  uint16_t min;                  //!< minimum
+  int16_t min;                  //!< minimum
   byte p25_out_count;            //!< count of datasets below p25, including mininal value
-  uint16_t p25;                  //!< 25th percentile
+  int16_t p25;                  //!< 25th percentile
   T mean;                        //!< average 
-  uint16_t median;               //!< 50th percentile
-  uint16_t p75;                  //!< 75th percentile
+  int16_t median;               //!< 50th percentile
+  int16_t p75;                  //!< 75th percentile
   byte p75_out_count;            //!< count of datasets above p75, including maximum value
-  uint16_t max;                  //!< maximum
+  int16_t max;                  //!< maximum
 };
 
 //Data structure for value-range (min, mean, max values)
@@ -106,10 +106,10 @@ typedef struct {
   float Cvolts_stdev;            //!< calculated standard deviation (populated)
   
   Stats_t<float> Ccap_As;        //!< cell capacity statistics calculated from individual cell data
-  int16_t CAP2_mean;             //!< cap mean from impedance track cap measurement
-  int16_t CAPusable_max;         //!< usable Ah by latest charge (As/10)
-  int16_t CAP_min_at;            //!< cell number with capacity mininum in pack
-  int16_t CAP_max_at;            //!< cell number with capacity maximum in pack
+  uint16_t CAP2_mean;             //!< cap mean from impedance track cap measurement
+  uint16_t CAPusable_max;         //!< usable Ah by latest charge (As/10)
+  uint16_t CAP_min_at;            //!< cell number with capacity mininum in pack
+  uint16_t CAP_max_at;            //!< cell number with capacity maximum in pack
   
   uint16_t CapInit;              //!< battery initial capacity (x/16) in As/10 at a certain/defined temperature maybe 45 degC
   uint16_t CapMeas;              //!< battery capacity measured in As/10

--- a/ED4scan/_OBL_dfs.h
+++ b/ED4scan/_OBL_dfs.h
@@ -19,7 +19,7 @@
 //! \brief   Definitions and structures for the On-Board-Loader (Charger) module.
 //! \date    2018-April
 //! \author  MyLab-odyssey
-//! \version 0.4.2
+//! \version 0.4.4
 //--------------------------------------------------------------------------------
 #ifndef OBL_DFS_H
 #define OBL_DFS_H
@@ -27,10 +27,10 @@
 //Definitions for OBL
 #define TEMP_OFFSET 50
 
-char* const PROGMEM OBL_ID[] ={"22KW", "7KW"};
-char* const PROGMEM ID_7KW = "2239";
-char* const PROGMEM OBL_STATE[] ={"CHG", "ON", "STBY"};
-char* const PROGMEM PILOT_STATE[] ={"-", "B", "C", "D", "E"};
+const char* const PROGMEM OBL_ID[] ={"22KW", "7KW"};
+const char* const PROGMEM ID_7KW = "2239";
+const char* const PROGMEM OBL_STATE[] ={"CHG", "ON", "STBY"};
+const char* const PROGMEM PILOT_STATE[] ={"-", "B", "C", "D", "E"};
 
 //OBL data structure
 typedef struct {       

--- a/ED4scan/_TCU_dfs.h
+++ b/ED4scan/_TCU_dfs.h
@@ -19,12 +19,12 @@
 //! \brief   Definitions and structures for the Tele-Communication Unit.
 //! \date    2018-April
 //! \author  MyLab-odyssey
-//! \version 0.4.2
+//! \version 0.4.3
 //--------------------------------------------------------------------------------
 #ifndef TCU_DFS_H
 #define TCU_DFS_H
 
-char* const PROGMEM TCU_MODE[] ={"OFF", "ON", "?", "CN"};
+const char* const PROGMEM TCU_MODE[] ={"OFF", "ON", "?", "CN"};
 
 struct TCUdatetime {
   byte year = 0;

--- a/ED4scan/canDiagED4.cpp
+++ b/ED4scan/canDiagED4.cpp
@@ -1417,18 +1417,11 @@ char canDiag::OBL_7KW_Installed(ChargerDiag_t *myOBL, boolean debug_verbose) {
   this->setCAN_ID(rqID_OBL, respID_OBL);
   items = this->Request_Diagnostics(rqIDpart);
   
-  if (items){
+  if (items) {
     if (debug_verbose) {
        PrintReadBuffer(items);
     }
-    byte n;
-    byte comp = 0;
-    for (n = 3; n < 7; n++) {
-        if (data[n] != ID_7KW[n - 3]) {
-          comp++;
-        }
-    }
-    if (comp == 4){
+    if (strcmp_P((const char *) (data + 3), ID_7KW) == 0) {
       return true;
     } else {
       return false;

--- a/ED4scan/canDiagED4.cpp
+++ b/ED4scan/canDiagED4.cpp
@@ -19,7 +19,7 @@
 //! \brief   Library module for retrieving diagnostic data.
 //! \date    2018-April
 //! \author  MyLab-odyssey
-//! \version 0.4.2
+//! \version 0.4.3
 //--------------------------------------------------------------------------------
 #include "canDiagED4.h"
 
@@ -126,12 +126,12 @@ void canDiag::setCAN_Filter(unsigned long filter) {
 void canDiag::setCAN_Filter_DRV() {
   myCAN0->init_Mask(0, 0, 0x07FF0000);
   myCAN0->init_Mask(1, 0, 0x07FF0000);
-  myCAN0->init_Filt(0, 0, (0x200 << 16));
-  myCAN0->init_Filt(1, 0, (0x318 << 16));
-  myCAN0->init_Filt(2, 0, (0x3CE << 16));
-  myCAN0->init_Filt(3, 0, (0x3F2 << 16));
-  myCAN0->init_Filt(4, 0, (0x3D7 << 16));
-  myCAN0->init_Filt(5, 0, (0x504 << 16));
+  myCAN0->init_Filt(0, 0, 0x00020000);
+  myCAN0->init_Filt(1, 0, 0x00031800);
+  myCAN0->init_Filt(2, 0, 0x0003CE00);
+  myCAN0->init_Filt(3, 0, 0x0003F200);
+  myCAN0->init_Filt(4, 0, 0x0003D700);
+  myCAN0->init_Filt(5, 0, 0x00050400);
   //delay(100);
   myCAN0->setMode(MCP_NORMAL);                     // Set operation mode to normal so the MCP2515 sends acks to received data.
 }
@@ -298,7 +298,7 @@ boolean canDiag::Read_FC_Response(int16_t items) {
 
   byte i;
   int16_t n = 7;
-  int16_t rspLine = 0;
+  uint16_t rspLine = 0;
   int16_t FC_count = 0;
   byte FC_length = rqFlowControl[1];
   boolean fDiagOK = false;
@@ -584,8 +584,8 @@ boolean canDiag::getBatteryDate(BatteryDiag_t *myBMS, boolean debug_verbose) {
 //! \return  report success (boolean)
 //--------------------------------------------------------------------------------
 boolean canDiag::getBatteryVIN(BatteryDiag_t *myBMS, boolean debug_verbose) {
-
-  uint16_t items;
+  (void) myBMS;
+  uint16_t items = 0;
 
   this->setCAN_ID(0x7E7, 0x7EF);
   //items = this->Request_Diagnostics(rqBattVIN);
@@ -695,7 +695,7 @@ boolean canDiag::getBatteryCapacity(BatteryDiag_t *myBMS, boolean debug_verbose)
 
     if (CapMode == 1) {
       CellCapacity.clear();
-      this->ReadCellCapacity(data, 16, (CELLCOUNT / 2)); //data starting at #16, but two mean values pushed besfore!
+      this->ReadCellCapacity(data, 16, (CELLCOUNT / 2)); //data starting at #16, but two mean values pushed before!
     }
 
     fOK = true;
@@ -720,9 +720,9 @@ boolean canDiag::getBatteryCapacity(BatteryDiag_t *myBMS, boolean debug_verbose)
     if (CapMode == 1) {
       this->ReadCellCapacity(data, 3, CELLCOUNT / 2);
 
-      myBMS->Ccap_As.min = CellCapacity.minimum(&myBMS->CAP_min_at);
+      myBMS->Ccap_As.min = CellCapacity.minimum((int16_t *)&myBMS->CAP_min_at);
       CellCapacity.push(myBMS->Ccap_As.min); CellCapacity.push(myBMS->Ccap_As.min);
-      myBMS->Ccap_As.max = CellCapacity.maximum(&myBMS->CAP_max_at);
+      myBMS->Ccap_As.max = CellCapacity.maximum((int16_t *)&myBMS->CAP_max_at);
       myBMS->Ccap_As.mean = CellCapacity.mean();
     }
 
@@ -759,8 +759,8 @@ boolean canDiag::getBatteryCapacity(BatteryDiag_t *myBMS, boolean debug_verbose)
     }
     if (CapMode == 2) {
       this->ReadCellCapacity(data, 3, CELLCOUNT / 2);
-      myBMS->Ccap_As.min = CellCapacity.minimum(&myBMS->CAP_min_at) * 10;
-      myBMS->Ccap_As.max = CellCapacity.maximum(&myBMS->CAP_max_at) * 10;
+      myBMS->Ccap_As.min = CellCapacity.minimum((int16_t *)&myBMS->CAP_min_at) * 10;
+      myBMS->Ccap_As.max = CellCapacity.maximum((int16_t *)&myBMS->CAP_max_at) * 10;
       myBMS->Ccap_As.mean = CellCapacity.mean() * 10;
     }
 
@@ -1068,7 +1068,7 @@ boolean canDiag::getBatterySOH(BatteryDiag_t *myBMS, boolean debug_verbose) {
 boolean canDiag::getODOcount(BatteryDiag_t *myBMS, boolean debug_verbose) {
 
   uint16_t items;
-  int16_t value = 0;
+  uint16_t value = 0;
   bool fOK = false;
 
   this->setCAN_ID(rqID_DASH, respID_DASH);
@@ -1108,7 +1108,7 @@ boolean canDiag::getODOcount(BatteryDiag_t *myBMS, boolean debug_verbose) {
 boolean canDiag::getRange(BatteryDiag_t *myBMS, boolean debug_verbose) {
 
   uint16_t items;
-  int16_t value = 0;
+  uint16_t value = 0;
   bool fOK = false;
 
   this->setCAN_ID(rqID_EVC, respID_EVC);
@@ -1170,7 +1170,7 @@ boolean canDiag::getHVcontactorCount(BatteryDiag_t *myBMS, boolean debug_verbose
 //! \return  report success (boolean)
 //--------------------------------------------------------------------------------
 boolean canDiag::printOCVtable(BatteryDiag_t *myBMS, boolean debug_verbose) {
-
+  (void) myBMS;
   uint16_t items;
   uint16_t value;
   bool fOK = false;
@@ -1205,9 +1205,9 @@ boolean canDiag::printOCVtable(BatteryDiag_t *myBMS, boolean debug_verbose) {
 //! \return  report success (boolean)
 //--------------------------------------------------------------------------------
 boolean canDiag::printRESfactors(BatteryDiag_t *myBMS, boolean debug_verbose) {
-
+  (void) myBMS;
   uint16_t items;
-  byte offset;
+  byte offset = 0;
   uint16_t value;
   bool fOK = false;
 
@@ -1256,10 +1256,8 @@ boolean canDiag::printRESfactors(BatteryDiag_t *myBMS, boolean debug_verbose) {
 //! \return  report success (boolean)
 //--------------------------------------------------------------------------------
 boolean canDiag::printBMSlog(BatteryDiag_t *myBMS, boolean debug_verbose) {
-
+  (void) myBMS;
   uint16_t items;
-  byte offset;
-  uint16_t value;
   bool fOK = false;
 
   this->setCAN_ID(rqID_BMS, respID_BMS);
@@ -1318,7 +1316,6 @@ void canDiag::printBMSlogSet(byte _length) {
 boolean canDiag::printCHGlog(boolean debug_verbose) {
 
   uint16_t items;
-  uint16_t value;
   bool fOK = false;
 
   //Structure for Log-Dataset
@@ -1414,7 +1411,7 @@ boolean canDiag::printCHGlog(boolean debug_verbose) {
 //! \return  report success (boolean)
 //--------------------------------------------------------------------------------
 char canDiag::OBL_7KW_Installed(ChargerDiag_t *myOBL, boolean debug_verbose) {
-
+  (void) myOBL;
   uint16_t items;
 
   this->setCAN_ID(rqID_OBL, respID_OBL);
@@ -1427,7 +1424,7 @@ char canDiag::OBL_7KW_Installed(ChargerDiag_t *myOBL, boolean debug_verbose) {
     byte n;
     byte comp = 0;
     for (n = 3; n < 7; n++) {
-        if (strcmp_P(data[n], ID_7KW[n - 3])) {
+        if (data[n] != ID_7KW[n - 3]) {
           comp++;
         }
     }
@@ -1931,7 +1928,7 @@ boolean canDiag::getTCUdata(TCUdiag_t *myTCU, boolean debug_verbose) {
 //! \return  report success (boolean)
 //--------------------------------------------------------------------------------
 boolean canDiag::getTCUnetwork(TCUdiag_t *myTCU, boolean debug_verbose) {
-
+  (void) myTCU;
   uint16_t items;
   boolean fOK = false;
 

--- a/ED4scan/canDiagED4.cpp
+++ b/ED4scan/canDiagED4.cpp
@@ -126,12 +126,12 @@ void canDiag::setCAN_Filter(unsigned long filter) {
 void canDiag::setCAN_Filter_DRV() {
   myCAN0->init_Mask(0, 0, 0x07FF0000);
   myCAN0->init_Mask(1, 0, 0x07FF0000);
-  myCAN0->init_Filt(0, 0, 0x00020000);
-  myCAN0->init_Filt(1, 0, 0x00031800);
-  myCAN0->init_Filt(2, 0, 0x0003CE00);
-  myCAN0->init_Filt(3, 0, 0x0003F200);
-  myCAN0->init_Filt(4, 0, 0x0003D700);
-  myCAN0->init_Filt(5, 0, 0x00050400);
+  myCAN0->init_Filt(0, 0, 0x02000000);
+  myCAN0->init_Filt(1, 0, 0x03180000);
+  myCAN0->init_Filt(2, 0, 0x03CE0000);
+  myCAN0->init_Filt(3, 0, 0x03F20000);
+  myCAN0->init_Filt(4, 0, 0x03D70000);
+  myCAN0->init_Filt(5, 0, 0x05040000);
   //delay(100);
   myCAN0->setMode(MCP_NORMAL);                     // Set operation mode to normal so the MCP2515 sends acks to received data.
 }

--- a/ED4scan/canDiagED4.cpp
+++ b/ED4scan/canDiagED4.cpp
@@ -1421,7 +1421,7 @@ char canDiag::OBL_7KW_Installed(ChargerDiag_t *myOBL, boolean debug_verbose) {
     if (debug_verbose) {
        PrintReadBuffer(items);
     }
-    if (strcmp_P((const char *) (data + 3), ID_7KW) == 0) {
+    if (memcmp_P((const char *) (data + 3), ID_7KW, 4) == 0) {
       return true;
     } else {
       return false;

--- a/ED4scan/canDiagED4.h
+++ b/ED4scan/canDiagED4.h
@@ -19,7 +19,7 @@
 //! \brief   Library module for retrieving diagnostic data. 
 //! \date    2018-April
 //! \author  MyLab-odyssey
-//! \version 0.4.2
+//! \version 0.4.3
 //--------------------------------------------------------------------------------
 #ifndef CANDIAG_H
 #define CANDIAG_H


### PR DESCRIPTION
Hi Ralph,

Here's a pull request that eliminates compiler warnings against Arduino version 1.8.5 with -Wall enabled.

I don't think any of them are likely to change program functionality except the code that detects whether the 7kW charger is installer. I think that series of 4 string comparisons was just flat out wrong initially, which means I'm not sure what I changed it to is going to work as intended (but what was there was almost surely not going to work as intended either...)

I also noticed that the use of AvgNew is designed around int16s and you're passing uint16s. Consider whether that's possibly the source of any weirdness?

Have a look at the change around setCAN_Filter_DRV. I'm pretty sure I got that right, but I initially made a mistake, so take a look.

Also, you had the potential for an array access out of range in printBMSall and an uninitialized variable in printRESFactors that would cause the code to print a semi-random label in front of the values you read from the BMS. (I doubt this was a source of confusion, but maybe.)